### PR TITLE
Fix assertion error when matching a decorator on top of a lookupelement

### DIFF
--- a/src/main/java/com/tabnine/TabNineCompletionContributor.java
+++ b/src/main/java/com/tabnine/TabNineCompletionContributor.java
@@ -113,6 +113,9 @@ public class TabNineCompletionContributor extends CompletionContributor {
         public boolean prefixMatches(@NotNull LookupElement element) {
             if (element instanceof TabNineLookupElement) {
                 return true;
+            } else if (element instanceof LookupElementDecorator) {
+                LookupElementDecorator decorator = (LookupElementDecorator) element;
+                return prefixMatches(decorator.getDelegate());
             }
             return super.prefixMatches(element);
         }


### PR DESCRIPTION
Recursively check delegates in the case the lookup element is a wrapper.
Fixes #5.
In the case of the error reported, it seems that it is caused by the `LookupElement` being wrapped with a `PolicyDecorator` by `CompletionService`.